### PR TITLE
Fix unallocated memory access

### DIFF
--- a/include/core.h
+++ b/include/core.h
@@ -4,7 +4,7 @@
 #include <iostream>
 #include <vector>
 
-#define ERR_STR_LEN 100
+#define ERR_STR_LEN 200
 
 /**
  * @brief ベクトルの表示

--- a/src/core.cpp
+++ b/src/core.cpp
@@ -18,7 +18,7 @@ long prime(const long n)
 {
     if(n <= 0)
     {
-        char *err_s;
+        char err_s[ERR_STR_LEN];
         sprintf(err_s, "The %ld-th prime number cannot be defined.", n);
         throw std::invalid_argument(err_s);
     }
@@ -48,7 +48,7 @@ V dot(const std::vector<U> x, const std::vector<V> y)
 {
     if (x.size() != y.size())
     {
-        char *err_s;
+        char err_s[ERR_STR_LEN];
         sprintf(err_s, "An inner product of %ld-th vector and %ld-th vector cannot be defined.", x.size(), y.size());
         throw std::invalid_argument(err_s);
     }


### PR DESCRIPTION
In core.cpp `char* err_s` passed to `sprintf` is not initialized, which is invalid memory access.

Additionally, in lattice.cpp (at line 494) more than 100 characters are written to `char err_s[ERR_STR_LEN]` while `ERR_STR_LEN` is set to `100`.

This PR fixes these issues.